### PR TITLE
Ignorable field test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,5 +26,5 @@ test {
 }
 
 jmh {
-    includes = ['org.example.jackson.bench.BigIntegerParserBench']
+    includes = ['org.example.jackson.bench.BigIntegerJsonParseBench']
 }

--- a/src/jmh/java/org/example/jackson/bench/BigIntegerJsonParseBench.java
+++ b/src/jmh/java/org/example/jackson/bench/BigIntegerJsonParseBench.java
@@ -1,0 +1,44 @@
+package org.example.jackson.bench;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class BigIntegerJsonParseBench extends BenchmarkLauncher {
+
+    static String test1000;
+    static String test1000000;
+
+    static {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            stringBuilder.append(7);
+        }
+        test1000 = stringBuilder.toString();
+        for (int i = 1000; i < 1000000; i++) {
+            stringBuilder.append(7);
+        }
+        test1000000 = stringBuilder.toString();
+    }
+
+    static ObjectMapper objectMapper = JsonMapper.builder().build();
+    
+    @Benchmark
+    public void bigParse1000() throws Exception {
+        objectMapper.readValue(genJson(test1000), ExtractFields.class);
+    }
+
+    @Benchmark
+    public void bigParse1000000() throws Exception {
+        objectMapper.readValue(genJson(test1000000), ExtractFields.class);
+    }
+
+    private String genJson(String num) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder
+                .append("{\"s\":\"s\",\"n\":")
+                .append(num)
+                .append(",\"i\":1}");
+        return stringBuilder.toString();
+    }
+}

--- a/src/jmh/java/org/example/jackson/bench/BigIntegerJsonParseBench.java
+++ b/src/jmh/java/org/example/jackson/bench/BigIntegerJsonParseBench.java
@@ -1,5 +1,6 @@
 package org.example.jackson.bench;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -21,7 +22,9 @@ public class BigIntegerJsonParseBench extends BenchmarkLauncher {
         test1000000 = stringBuilder.toString();
     }
 
-    static ObjectMapper objectMapper = JsonMapper.builder().build();
+    static ObjectMapper objectMapper = JsonMapper.builder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
     
     @Benchmark
     public void bigParse1000() throws Exception {

--- a/src/jmh/java/org/example/jackson/bench/BigIntegerParserBench.java
+++ b/src/jmh/java/org/example/jackson/bench/BigIntegerParserBench.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.io.BigDecimalParser;
 import org.openjdk.jmh.annotations.Benchmark;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 
 public class BigIntegerParserBench extends BenchmarkLauncher {
     static String test1000;

--- a/src/jmh/java/org/example/jackson/bench/ExtractFields.java
+++ b/src/jmh/java/org/example/jackson/bench/ExtractFields.java
@@ -1,0 +1,24 @@
+package org.example.jackson.bench;
+
+public class ExtractFields {
+    private final String s;
+    private final int i;
+
+    public ExtractFields() {
+        this.s = null;
+        this.i = -1;
+    }
+
+    public ExtractFields(String s, int i) {
+        this.s = s;
+        this.i = i;
+    }
+
+    public String getS() {
+        return s;
+    }
+
+    public int getI() {
+        return i;
+    }
+}


### PR DESCRIPTION
shows that ignorable fields can slow down deserialization (bigger data in ignorable field, slower processing)