### PR TITLE
Make JMH JAR a multi-release JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id "me.champeau.jmh" version "0.6.8"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
 }
 
 group 'org.example'
@@ -24,6 +25,12 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+jmhJar {
+    manifest {
+       attributes 'Multi-Release': 'true'
+    }
 }
 
 jmh {


### PR DESCRIPTION
fastdoubleparser is a [Multi-Release JAR](https://openjdk.org/jeps/238) and gets shaded into the JMH JAR. For the multi-release mechanism to work the JMH JAR needs to be a Multi-Release JAR. The JMH Gradle Plugin does not do this out of the box. The Shadow Plugin allows us to add a Multi-Release header to the JMH JAR.